### PR TITLE
JDK Priority

### DIFF
--- a/jdk.plugin/install.sh
+++ b/jdk.plugin/install.sh
@@ -23,7 +23,7 @@ else
 fi
 
 mkdir -p /usr/lib/jvm /usr/lib/jvm-exports
-alternatives --install /usr/bin/java java /usr/java/latest/bin/java 200000 \
+alternatives --install /usr/bin/java java /usr/java/latest/bin/java 2000000 \
 --slave /usr/lib/jvm/jre jre /usr/java/latest/jre \
 --slave /usr/lib/jvm-exports/jre jre_exports /usr/java/latest/jre/lib \
 --slave /usr/bin/keytool keytool /usr/java/latest/jre/bin/keytool \
@@ -44,7 +44,7 @@ alternatives --install /usr/bin/java java /usr/java/latest/bin/java 200000 \
 --slave /usr/share/man/man1/tnameserv.1 tnameserv.1 /usr/java/latest/man/man1/tnameserv.1 \
 --slave /usr/share/man/man1/unpack200.1 unpack200.1 /usr/java/latest/man/man1/unpack200.1
 alternatives --auto java
-alternatives --install /usr/bin/javac javac /usr/java/latest/bin/javac 200000 \
+alternatives --install /usr/bin/javac javac /usr/java/latest/bin/javac 2000000 \
 --slave /usr/lib/jvm/java java_sdk /usr/java/latest \
 --slave /usr/lib/jvm-exports/java java_sdk_exports /usr/java/latest/lib \
 --slave /usr/bin/appletviewer appletviewer /usr/java/latest/bin/appletviewer \
@@ -105,9 +105,9 @@ alternatives --install /usr/bin/javac javac /usr/java/latest/bin/javac 200000 \
 alternatives --auto javac
 
 if [[ "$arch" = "x86" ]]; then
-    alternatives --install /usr/lib/mozilla/plugins/libjavaplugin.so libjavaplugin.so /usr/java/latest/lib/i386/libnpjp2.so 200000
+    alternatives --install /usr/lib/mozilla/plugins/libjavaplugin.so libjavaplugin.so /usr/java/latest/lib/i386/libnpjp2.so 2000000
     alternatives --auto libjavaplugin.so
 elif [[ "$arch" = "x64" ]]; then
-    alternatives --install /usr/lib64/mozilla/plugins/libjavaplugin.so libjavaplugin.so.x86_64 /usr/java/latest/lib/amd64/libnpjp2.so 200000
+    alternatives --install /usr/lib64/mozilla/plugins/libjavaplugin.so libjavaplugin.so.x86_64 /usr/java/latest/lib/amd64/libnpjp2.so 2000000
     alternatives --auto libjavaplugin.so.x86_64
 fi


### PR DESCRIPTION
Fixed installation under Fedora 23. Oracle JDK priority is now higher than Open JDK.