### PR TITLE
Update link to get IntelliJ IDEA Community binary

### DIFF
--- a/intellijideacommunity.plugin/install.sh
+++ b/intellijideacommunity.plugin/install.sh
@@ -6,7 +6,7 @@ CACHEDIR="/var/cache/fedy/intellij-idea-community";
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-URL=$(wget "https://www.jetbrains.com/idea/download/download_thanks.jsp?os=linux&edition=IC" -O - | grep -o "https://download.jetbrains.com/idea/ideaIC-[0-9.]*.tar.gz" | head -n 1)
+URL=https://download.jetbrains.com/idea/ideaIC-$(wget "https://confluence.jetbrains.com/display/IDEADEV/Home" -O - | grep -Po "IntelliJ IDEA [0-9.]* Release Notes" | grep -o [0-9.]* | tail -n 1).tar.gz
 FILE=${URL##*/}
 
 wget -c "$URL" -O "$FILE"


### PR DESCRIPTION
This update uses the Release notes instead of the actual download website to get the latest version string. 

There's however one drawback that only packages having version string *ab.y.z* can be obtained.

For example if the download site provides *Version: 15.0 (ideaIC-15.0.tar.gz)*, it probably won't have a release note (I don't understand why?) on the used link. As a result the script will install the last *Version: 14.x.y (ideaIC-14.x.y.tar.gz)* package.

Additional lines can be added to the script as a workaround if there's no better way to do this.

Should close https://github.com/folkswithhats/fedy-plugins-developers/issues/13.