### PR TITLE
Update all JetBrains IDEs download link

### DIFF
--- a/intellijideacommunity.plugin/install.sh
+++ b/intellijideacommunity.plugin/install.sh
@@ -6,7 +6,7 @@ CACHEDIR="/var/cache/fedy/intellij-idea-community";
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-URL=https://download.jetbrains.com/idea/ideaIC-$(wget "https://confluence.jetbrains.com/display/IDEADEV/Home" -O - | grep -Po "IntelliJ IDEA [0-9.]* Release Notes" | grep -o [0-9.]* | tail -n 1).tar.gz
+URL=$(wget "https://data.services.jetbrains.com/products/releases?code=IIC&latest=true" -O -| grep -o "https://download.jetbrains.com/idea/ideaIC-[0-9.]*.tar.gz" | head -n 1)
 FILE=${URL##*/}
 
 wget -c "$URL" -O "$FILE"

--- a/intellijideaultimate.plugin/install.sh
+++ b/intellijideaultimate.plugin/install.sh
@@ -6,7 +6,7 @@ CACHEDIR="/var/cache/fedy/intellij-idea-ultimate";
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-URL=https://download.jetbrains.com/idea/ideaIU-$(wget "https://confluence.jetbrains.com/display/IDEADEV/Home" -O - | grep -Po "IntelliJ IDEA [0-9.]* Release Notes" | grep -o [0-9.]* | tail -n 1).tar.gz
+URL=$(wget "https://data.services.jetbrains.com/products/releases?code=IIU&latest=true" -O -| grep -o "https://download.jetbrains.com/idea/ideaIU-[0-9.]*.tar.gz" | head -n 1)
 FILE=${URL##*/}
 
 wget -c "$URL" -O "$FILE"

--- a/phpstorm.plugin/install.sh
+++ b/phpstorm.plugin/install.sh
@@ -6,7 +6,7 @@ CACHEDIR="/var/cache/fedy/phpstorm";
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-URL=$(wget "https://www.jetbrains.com/phpstorm/download/download_thanks.jsp?os=linux" -O - | grep -o "https://download.jetbrains.com/webide/PhpStorm-[0-9.]*.tar.gz" | head -n 1)
+URL=$(wget "https://data.services.jetbrains.com/products/releases?code=PS&latest=true" -O -| grep -o "https://download.jetbrains.com/webide/PhpStorm-[0-9.]*.tar.gz" | head -n 1)
 FILE=${URL##*/}
 
 wget -c "$URL" -O "$FILE"

--- a/pycharmprofessional.plugin/install.sh
+++ b/pycharmprofessional.plugin/install.sh
@@ -6,7 +6,7 @@ CACHEDIR="/var/cache/fedy/pycharm-professional";
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-URL=$(wget "https://www.jetbrains.com/pycharm/download/download_thanks.jsp?os=linux" -O - | grep -o "https://download.jetbrains.com/python/pycharm-professional-[0-9.]*.tar.gz" | head -n 1)
+URL=$(wget "https://data.services.jetbrains.com/products/releases?code=PCP&latest=true" -O - | grep -o "https://download.jetbrains.com/python/pycharm-professional-[0-9.]*.tar.gz" | head -n 1)
 FILE=${URL##*/}
 
 wget -c "$URL" -O "$FILE"

--- a/rubymine.plugin/install.sh
+++ b/rubymine.plugin/install.sh
@@ -6,7 +6,7 @@ CACHEDIR="/var/cache/fedy/rubymine";
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-URL=$(wget "https://www.jetbrains.com/ruby/download/download_thanks.jsp?os=linux" -O - | grep -o "https://download.jetbrains.com/ruby/RubyMine-[0-9.]*.tar.gz" | head -n 1)
+URL=$(wget "https://data.services.jetbrains.com/products/releases?code=RM&latest=true" -O - | grep -o "https://download.jetbrains.com/ruby/RubyMine-[0-9.]*.tar.gz" | head -n 1)
 FILE=${URL##*/}
 
 wget -c "$URL" -O "$FILE"

--- a/webstorm.plugin/install.sh
+++ b/webstorm.plugin/install.sh
@@ -6,7 +6,7 @@ CACHEDIR="/var/cache/fedy/webstorm";
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-URL=$(wget "https://www.jetbrains.com/webstorm/download/download_thanks.jsp?os=linux" -O - | grep -o "https://download.jetbrains.com/webstorm/WebStorm-[0-9.]*.tar.gz" | head -n 1)
+URL=$(wget "https://data.services.jetbrains.com/products/releases?code=WS&latest=true" -O - | grep -o "https://download.jetbrains.com/webstorm/WebStorm-[0-9.]*.tar.gz" | head -n 1)
 FILE=${URL##*/}
 
 wget -c "$URL" -O "$FILE"


### PR DESCRIPTION
Recent updates to the JetBrains website - https://www.jetbrains.com/ rendered all download links to their IDEs useless. This is a patch to fix that.
Download links are now obtained directly from XHR objects.