### PR TITLE
Fix for latest Webstorm version

### DIFF
--- a/webstorm.plugin/install.sh
+++ b/webstorm.plugin/install.sh
@@ -6,7 +6,7 @@ CACHEDIR="/var/cache/fedy/webstorm";
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-URL=$(wget "https://data.services.jetbrains.com/products/releases?code=WS&latest=true" -O - | grep -o "https://download.jetbrains.com/webstorm/WebStorm-[0-9.]*.tar.gz" | head -n 1)
+URL=$(wget "https://data.services.jetbrains.com/products/releases?code=WS&latest=true" -O - | grep -o "https://download.jetbrains.com/webstorm/WebStorm-[0-9a-z.]*.tar.gz" | head -n 1)
 FILE=${URL##*/}
 
 wget -c "$URL" -O "$FILE"


### PR DESCRIPTION
It has a letter, so the regex wasn't matching the version string (2016.1.2b).