### PR TITLE
Fix clion url

### DIFF
--- a/clion.plugin/install.sh
+++ b/clion.plugin/install.sh
@@ -6,18 +6,14 @@ CACHEDIR="/var/cache/fedy/clion";
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-URL=$(wget "https://data.services.jetbrains.com/products/releases?code=CL&latest=true" -O - | grep -o "https://download.jetbrains.com/cpp/clion-[0-9.]*.tar.gz" | head -n 1)
+URL=$(wget "https://data.services.jetbrains.com/products/releases?code=CL&latest=true" -O - | grep -o "https://download.jetbrains.com/cpp/CLion-[0-9.]*.tar.gz" | head -n 1)
 FILE=${URL##*/}
 
-wget -c "$URL" -O "$FILE"
+[[ -f "$FILE" ]] ||	wget -c "$URL" -O "$FILE"
+[[ -f "$FILE" ]] || exit 1
 
-if [[ ! -f "$FILE" ]]; then
-	exit 1
-fi
-
-tar -xzf "$FILE" -C "/opt/"
-
-mv /opt/clion* "/opt/clion"
+mkdir "/opt/clion/"
+tar -xzf "$FILE" -C "/opt/clion" --strip-components=1
 ln -sf "/opt/clion/bin/clion.sh" "/usr/bin/clion"
 
 xdg-icon-resource install --novendor --size 128 "/opt/clion/bin/clion.svg" "clion"
@@ -26,7 +22,7 @@ gtk-update-icon-cache -f -t /usr/share/icons/hicolor
 cat <<EOF | tee /usr/share/applications/clion.desktop
 [Desktop Entry]
 Name=CLion
-Icon=clion
+Icon=/opt/clion/bin/clion.svg
 Comment=This powerful IDE helps you develop in C and C++ on Linux
 Exec=clion
 Terminal=false

--- a/clion.plugin/install.sh
+++ b/clion.plugin/install.sh
@@ -9,7 +9,7 @@ cd "$CACHEDIR"
 URL=$(wget "https://data.services.jetbrains.com/products/releases?code=CL&latest=true" -O - | grep -o "https://download.jetbrains.com/cpp/CLion-[0-9.]*.tar.gz" | head -n 1)
 FILE=${URL##*/}
 
-[[ -f "$FILE" ]] ||	wget -c "$URL" -O "$FILE"
+[[ -f "$FILE" ]] || wget -c "$URL" -O "$FILE"
 [[ -f "$FILE" ]] || exit 1
 
 mkdir "/opt/clion/"


### PR DESCRIPTION
- Fix clion url as specified in #26.
- Use cached tar if available and it's the latest version.
- Extract tar directly to target dir.
- Fix icon in `.desktop` file.

Closes #26.
